### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/templates/pindrop.template
+++ b/templates/pindrop.template
@@ -54,7 +54,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Handler: pdvalidate.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Description: Pindrop Validate Parameters
       MemorySize: 128
       Timeout: 30
@@ -80,7 +80,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Handler: callstart.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Description: Pindrop Call Start
       MemorySize: 128
       Timeout: 30
@@ -109,7 +109,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Handler: fetchcall.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Description: Pindrop Fetch Call
       MemorySize: 128
       Timeout: 30


### PR DESCRIPTION
CloudFormation templates in connect-integration-pindrop have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.